### PR TITLE
Fix router not found page

### DIFF
--- a/HybridHearth/HybridHearth.Shared/Routes.razor
+++ b/HybridHearth/HybridHearth.Shared/Routes.razor
@@ -1,6 +1,11 @@
-﻿<Router AppAssembly="typeof(Layout.MainLayout).Assembly">
+<Router AppAssembly="typeof(Layout.MainLayout).Assembly">
     <Found Context="routeData">
         <RouteView RouteData="routeData" DefaultLayout="typeof(Layout.MainLayout)" />
         <FocusOnNavigate RouteData="routeData" Selector="h1" />
     </Found>
+    <NotFound>
+        <LayoutView Layout="typeof(Layout.MainLayout)">
+            <p role="alert">Sorry, there's nothing at this address.</p>
+        </LayoutView>
+    </NotFound>
 </Router>


### PR DESCRIPTION
## Summary
- add a default NotFound section for the router so unknown routes render an error message

## Testing
- `git diff --cached --stat`


------
https://chatgpt.com/codex/tasks/task_e_6848231ac2288333813cd7a471510eae