### PR TITLE
Add not found block

### DIFF
--- a/HybridHearth/HybridHearth.Shared/Routes.razor
+++ b/HybridHearth/HybridHearth.Shared/Routes.razor
@@ -3,4 +3,9 @@
         <RouteView RouteData="routeData" DefaultLayout="typeof(Layout.MainLayout)" />
         <FocusOnNavigate RouteData="routeData" Selector="h1" />
     </Found>
+    <NotFound>
+        <LayoutView Layout="typeof(Layout.MainLayout)">
+            <p>Page not found.</p>
+        </LayoutView>
+    </NotFound>
 </Router>


### PR DESCRIPTION
## Summary
- add a NotFound block for missing pages

## Testing
- `apt-get update`
- `apt-get install -y dotnet-sdk-8.0`
- `dotnet build HybridHearth.sln` *(fails: NETSDK1045 unsupported target net9.0)*

------
https://chatgpt.com/codex/tasks/task_e_6848260551c08333aba01b82ccd1add1